### PR TITLE
Support Additional Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ You can also choose to have the script create security groups to facilitate the 
 If you are running the setup for an environment in which you have Global Admin permissions on the tenant, and you want to have security groups provisioned, you can invoke the setup script like this:\
 `./OpenEduAnalytics/setup.sh mysuffix eastus true`
 
-By default, the provisioned Azure resources are named according to [recommended Azure naming standards](https://github.com/microsoft/OpenEduAnalytics/wiki/Design-Decisions), however you can directly modify [set_names.sh](https://github.com/microsoft/OpenEduAnalytics/blob/main/set_names.sh) before running the setup if you want to specify an alternative set of resource names.
+By default, the provisioned Azure resources are named according to [recommended Azure naming standards](https://github.com/microsoft/OpenEduAnalytics/wiki/Design-Decisions), however you can directly modify [set_names.sh](https://github.com/microsoft/OpenEduAnalytics/blob/main/infrastructure/bash/set_names.sh) before running the setup if you want to specify an alternative set of resource names.
+
+Provisioned Azure resources are tagged with `oea_version`, if an Azure policy requires a specific tag(s) to be assigned when a resource is created these can be included via `$OEA_ADDITIONAL_TAGS` in [set_names.sh](https://github.com/microsoft/OpenEduAnalytics/blob/main/infrastructure/bash/set_names.sh) using the format `tagName=tagValue`, if multiple tags are required they need to be space separated. 
 
 ### Additional info
 You can get more info by reviewing the documentation available in the [docs](https://github.com/microsoft/OpenEduAnalytics/tree/main/docs) folder.

--- a/infrastructure/bash/set_names.sh
+++ b/infrastructure/bash/set_names.sh
@@ -17,4 +17,4 @@ export OEA_ML_WORKSPACE="mlw-oea-${org_id_lowercase}"
 export OEA_KEYVAULT="kv-oea-${org_id_lowercase}"
 export OEA_ML_STORAGE_ACCOUNT="stmloea${org_id_lowercase}"
 export OEA_APP_INSIGHTS="appi-oea-${org_id_lowercase}"
-
+export OEA_ADDITIONAL_TAGS=""

--- a/infrastructure/bash/setup_base_architecture.sh
+++ b/infrastructure/bash/setup_base_architecture.sh
@@ -41,7 +41,7 @@ az group create -l $location -n $OEA_RESOURCE_GROUP --tags oea_version=$OEA_VERS
 # 2) Create the storage account and containers - https://docs.microsoft.com/en-us/cli/azure/storage/account?view=azure-cli-latest#az_storage_account_create
 echo "--> 2) Creating storage account: ${OEA_STORAGE_ACCOUNT}"
 echo "--> 2) Creating storage account: ${OEA_STORAGE_ACCOUNT}" 1>&3
-az storage account create --resource-group $OEA_RESOURCE_GROUP --name ${OEA_STORAGE_ACCOUNT} --location $location --tags oea_version=$OEA_VERSION \
+az storage account create --resource-group $OEA_RESOURCE_GROUP --name ${OEA_STORAGE_ACCOUNT} --location $location --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS \
   --kind StorageV2 --sku Standard_RAGRS --enable-hierarchical-namespace true --access-tier Hot --default-action Allow
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 
@@ -61,7 +61,7 @@ az storage container create --account-name $OEA_STORAGE_ACCOUNT --name stage3p -
 echo "--> 3) Creating Synapse Workspace: $OEA_SYNAPSE (this is usually the longest step - it may take 5 to 10 minutes to complete)"
 echo "--> 3) Creating Synapse Workspace: $OEA_SYNAPSE (this is usually the longest step - it may take 5 to 10 minutes to complete)" 1>&3
 temporary_password="$(openssl rand -base64 12)" # Generate random password (because sql-admin-login-password is required, but not used in this solution)
-az synapse workspace create --name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP --tags oea_version=$OEA_VERSION \
+az synapse workspace create --name $OEA_SYNAPSE --resource-group $OEA_RESOURCE_GROUP --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS \
   --storage-account $OEA_STORAGE_ACCOUNT --file-system synapse-workspace --location $location \
   --sql-admin-login-user eduanalyticsuser --sql-admin-login-password $temporary_password
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
@@ -88,14 +88,14 @@ az synapse spark pool update --name spark3p1sm --workspace-name $OEA_SYNAPSE --r
 # 4) Create key vault for secure storage of credentials, and create app insights for logging
 echo "--> 4) Creating key vault: ${OEA_KEYVAULT}"
 echo "--> 4) Creating key vault: ${OEA_KEYVAULT}" 1>&3
-az keyvault create --name $OEA_KEYVAULT --resource-group $OEA_RESOURCE_GROUP --location $location --tags oea_version=$OEA_VERSION
+az keyvault create --name $OEA_KEYVAULT --resource-group $OEA_RESOURCE_GROUP --location $location --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 # give the Synapse workspace access to get secrets from the key vault, for use in Synapse pipelines
 az keyvault set-policy -n $OEA_KEYVAULT --secret-permissions get --object-id $synapse_principal_id
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 
 echo "--> Creating app-insights: $OEA_APP_INSIGHTS"
-az monitor app-insights component create --app $OEA_APP_INSIGHTS --resource-group $OEA_RESOURCE_GROUP --location $location --tags oea_version=$OEA_VERSION
+az monitor app-insights component create --app $OEA_APP_INSIGHTS --resource-group $OEA_RESOURCE_GROUP --location $location --tags oea_version=$OEA_VERSION $OEA_ADDITIONAL_TAGS
 [[ $? != 0 ]] && { echo "Provisioning of azure resource failed. See $logfile for more details." 1>&3; exit 1; }
 
 keyvault_id="/subscriptions/$subscription_id/resourceGroups/$OEA_RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$OEA_KEYVAULT"


### PR DESCRIPTION
- Problem

If an azure tenant has a policy in place that restricts infrastructure being created without a specific tag being included, the setup process will fail.  

- Solution

Any required tags can now be set within `set_name.sh` using a new variable `$OEA_ADDITIONAL_TAGS` this will append the additional tags to any existing `--tags` options within `setup_base_infrastructure.sh` 